### PR TITLE
11 review submissions

### DIFF
--- a/backend/formsapp/permissions.py
+++ b/backend/formsapp/permissions.py
@@ -22,3 +22,14 @@ class IsOwnerOrTeacherAdmin(BasePermission):
         if getattr(user, 'role', 'student') in ('teacher', 'admin'):
             return True
         return obj.user_id == user.id
+
+
+class IsTeacherOrAdmin(BasePermission):
+    """
+    Only teachers and admins are allowed (no access for students).
+    """
+    def has_permission(self, request, view):
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        return getattr(user, 'role', 'student') in ('teacher', 'admin')

--- a/backend/formsapp/urls.py
+++ b/backend/formsapp/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import FormViewSet, SubmissionViewSet
+from .views import FormViewSet, SubmissionViewSet, FormSubmissionListView
 
 router = DefaultRouter()
 router.register('forms', FormViewSet, basename='forms')
@@ -8,4 +8,9 @@ router.register('submissions', SubmissionViewSet, basename='submissions')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path(
+        'forms/<int:form_id>/submissions/',
+        FormSubmissionListView.as_view({'get': 'list'}),
+        name='form-submission-list',
+    ),
 ]


### PR DESCRIPTION
- added IsTeacherOrAdmin permission for teacher and admin-only endpoints

- added a form-scoped submissions list view for teachers and admins
- exposed /api/forms/<id>/submissions endpoint for form submission review